### PR TITLE
fix: optional user stacks array

### DIFF
--- a/app/assinante/[id]/page.tsx
+++ b/app/assinante/[id]/page.tsx
@@ -18,7 +18,7 @@ interface UserData {
   _id: string;
   email: string;
   seniorityLevel: string;
-  stacks: string[];
+  stacks?: string[];
   confirmed: boolean;
   createdAt: string;
 }
@@ -44,7 +44,7 @@ export default function SubscriberPage() {
         setUserData(data);
         setFormData({
           seniorityLevel: data.seniorityLevel,
-          stacks: data.stacks,
+          stacks: data.stacks || [],
         });
       } catch (error) {
         console.error("Erro ao buscar dados:", error);
@@ -167,7 +167,7 @@ export default function SubscriberPage() {
             <div>
               <label className="block text-sm font-medium mb-2">Área</label>
               <Select
-                value={formData.stacks?.[0] || ""}
+                value={formData.stacks[0] || ""}
                 onValueChange={(value) =>
                   setFormData({ ...formData, stacks: [value] })
                 }

--- a/app/assinante/[id]/page.tsx
+++ b/app/assinante/[id]/page.tsx
@@ -117,7 +117,7 @@ export default function SubscriberPage() {
       </div>
 
 
-     
+
       <div className="w-full max-w-2xl bg-white dark:bg-gray-800 rounded-xl shadow-xl p-6 sm:p-8">
         <h1 className="text-2xl sm:text-3xl font-bold mb-2">Painel de Assinante</h1>
         <p className="text-gray-600 dark:text-gray-300 mb-8">
@@ -167,7 +167,7 @@ export default function SubscriberPage() {
             <div>
               <label className="block text-sm font-medium mb-2">Área</label>
               <Select
-                value={formData.stacks[0] || ""}
+                value={formData.stacks?.[0] || ""}
                 onValueChange={(value) =>
                   setFormData({ ...formData, stacks: [value] })
                 }


### PR DESCRIPTION
**Problem**
I already had an account created before stack selection was possible. After this update, an error is triggered when trying to access the dashboard.
After a brief analysis, I noticed that the "stacks" property might not be present, a situation that isn't accounted for in the code.

**Solution**
The typing of the "users" object was corrected to account for the possible absence of the "stacks" property. Additionally, when populating the "stacks" property of the "formData" object, an empty array is used if the property is not present in the database response.