### PR TITLE
feat: add 2 github actions for automated email cron jobs

### DIFF
--- a/.github/workflows/send-problems-email-to-all.yml
+++ b/.github/workflows/send-problems-email-to-all.yml
@@ -1,0 +1,20 @@
+name: Send Problems Email to All Subscribers
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 17 * * 1,3"
+
+jobs:
+  trigger-problems-email:
+    runs-on: ubuntu-latest
+    env:
+      API_ENDPOINT: https://vaguinhas.com.br/api/emails/send-problems-email-to-all
+      API_TOKEN: ${{ secrets.JWT_SECRET }}
+
+    steps:
+      - name: Send problems email to all subscribers
+        run: |
+          curl -X GET "$API_ENDPOINT" \
+          -H "Content-Type: application/json" \
+          -H "Authorization: Bearer ${{ secrets.JWT_SECRET }}"

--- a/.github/workflows/send-support-us-email-to-all.yml
+++ b/.github/workflows/send-support-us-email-to-all.yml
@@ -1,0 +1,20 @@
+name: Send Support Us Email to All Subscribers
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 18 * * 2,5"
+
+jobs:
+  trigger-support-us-email:
+    runs-on: ubuntu-latest
+    env:
+      API_ENDPOINT: https://vaguinhas.com.br/api/emails/send-support-us-email-to-all
+      API_TOKEN: ${{ secrets.JWT_SECRET }}
+
+    steps:
+      - name: Send support us email to all subscribers
+        run: |
+          curl -X GET "$API_ENDPOINT" \
+          -H "Content-Type: application/json" \
+          -H "Authorization: Bearer ${{ secrets.JWT_SECRET }}"


### PR DESCRIPTION
## 🚀 O que foi feito
- Criado workflow `Send Support Us Email to All Subscribers`, agendado para rodar automaticamente às **terças e sextas-feiras às 18h (UTC)**
- Criado workflow `Send Problems Email to All Subscribers`, agendado para rodar automaticamente às **segundas e quartas-feiras às 17h (UTC)**

## 💬 Observações
- Os horários foram definidos provisoriamente, já que ainda não há uma definição clara do melhor momento para o envio dos e-mails no produto.

## 📎 Referências
- [#48 - Criar CRON jobs no GitHub Actions para envio automático de emails](https://github.com/jmgrd98/vaguinhas/issues/48)